### PR TITLE
 更换计算NSAttributedString高度方法及修复bug

### DIFF
--- a/JCAlertController/JCAlertController/AlertView/JCAlertView.m
+++ b/JCAlertController/JCAlertController/AlertView/JCAlertView.m
@@ -98,9 +98,10 @@
         CGRect contentFrame = self.contentView.frame;
         contentFrame.origin.y = titleHeight;
         
-        if (CGRectGetHeight(contentFrame) > self.style.alertView.maxHeight) {
+        CGFloat maxContentHeight = self.style.alertView.maxHeight - titleHeight - self.buttonHeight;
+        if (CGRectGetHeight(contentFrame) > maxContentHeight) {
             CGRect scrollFrame = contentFrame;
-            scrollFrame.size.height = self.style.alertView.maxHeight - titleHeight - self.buttonHeight;
+            scrollFrame.size.height = maxContentHeight;
             UIScrollView *contentScrollView = [[UIScrollView alloc] initWithFrame:scrollFrame];
             contentScrollView.contentSize = contentFrame.size;
             contentScrollView.backgroundColor = self.style.alertView.backgroundColor;

--- a/JCAlertController/JCAlertController/Category/NSAttributedString+JCCalculateSize.m
+++ b/JCAlertController/JCAlertController/Category/NSAttributedString+JCCalculateSize.m
@@ -11,14 +11,15 @@
 @implementation NSAttributedString (JCCalculateSize)
 
 - (CGSize)sizeWithMaxWidth:(CGFloat)maxWidth {
-    NSTextStorage *textStorage = [[NSTextStorage alloc] initWithAttributedString:self];
-    NSTextContainer *textContainer = [[NSTextContainer alloc] initWithSize:CGSizeMake(maxWidth, FLT_MAX)];
-    NSLayoutManager *layoutManager = [[NSLayoutManager alloc] init];
-    [layoutManager addTextContainer:textContainer];
-    [textStorage addLayoutManager:layoutManager];
-    [layoutManager glyphRangeForTextContainer:textContainer];
-    CGSize fitSize = [layoutManager usedRectForTextContainer:textContainer].size;
-    return fitSize;
-}
+    if ([self length] > 0) {
+        CGRect textRect = [self
+                           boundingRectWithSize:CGSizeMake(maxWidth, MAXFLOAT)
+                           options:(NSStringDrawingUsesLineFragmentOrigin |
+                                    NSStringDrawingUsesFontLeading)
+                           context:nil];
+        return CGSizeMake(ceilf(textRect.size.width), ceilf(textRect.size.height));
+    } else {
+        return CGSizeZero;
+    }}
 
 @end


### PR DESCRIPTION
1. 修复之前提的代码计算contentView是否需要滚动条件bug，没有考虑标题、按钮的高度。
2. 原计算NSAttributedString高度方法在计算中文长文本时存在不准确的问题，推荐替换为boundingRectWithSize。